### PR TITLE
Feature/9591 enrolling and telemetry state context

### DIFF
--- a/state-api-iot-ensemble/Shared/UpdateTelemetrySync.cs
+++ b/state-api-iot-ensemble/Shared/UpdateTelemetrySync.cs
@@ -40,6 +40,10 @@ namespace LCU.State.API.IoTEnsemble.Shared
 
         [DataMember]
         public virtual int PageSize { get; set; }
+
+        
+        [DataMember]
+        public virtual string PayloadId { get; set; }
     }
 
     public class UpdateTelemetrySync
@@ -79,7 +83,7 @@ namespace LCU.State.API.IoTEnsemble.Shared
 
                         var stateDetails = StateUtils.LoadStateDetails(req);
 
-                        await harness.UpdateTelemetrySync(secMgr, docClient, dataReq.RefreshRate, dataReq.Page, dataReq.PageSize);
+                        await harness.UpdateTelemetrySync(secMgr, docClient, dataReq.RefreshRate, dataReq.Page, dataReq.PageSize, dataReq.PayloadId);
 
                         harness.State.Telemetry.Loading = false;
 

--- a/state-api-iot-ensemble/Shared/UpdateTelemetrySync.cs
+++ b/state-api-iot-ensemble/Shared/UpdateTelemetrySync.cs
@@ -40,7 +40,6 @@ namespace LCU.State.API.IoTEnsemble.Shared
 
         [DataMember]
         public virtual int PageSize { get; set; }
-
         
         [DataMember]
         public virtual string PayloadId { get; set; }

--- a/state-api-iot-ensemble/State/IoTEnsembleSharedState.cs
+++ b/state-api-iot-ensemble/State/IoTEnsembleSharedState.cs
@@ -91,6 +91,8 @@ namespace LCU.State.API.IoTEnsemble.State
             Storage = new IoTEnsembleStorageConfiguration();
             
             Telemetry = new IoTEnsembleTelemetry();
+
+            ExpandedPayloadID = null;
         }
         #endregion
     }
@@ -226,9 +228,6 @@ namespace LCU.State.API.IoTEnsemble.State
         [DataMember]
         [JsonProperty("id")]
         public virtual string ID { get; set; }
-
-        [DataMember]
-        public virtual bool IsExpanded { get; set; }
 
         [DataMember]
         public virtual MetadataModel SensorMetadata { get; set; }

--- a/state-api-iot-ensemble/State/IoTEnsembleSharedState.cs
+++ b/state-api-iot-ensemble/State/IoTEnsembleSharedState.cs
@@ -57,6 +57,9 @@ namespace LCU.State.API.IoTEnsemble.State
         public virtual ErrorContext Error { get; set; }
 
         [DataMember]
+        public virtual string ExpandedPayloadID { get; set; }
+
+        [DataMember]
         public virtual bool HasAccess { get; set; }
 
         [DataMember]

--- a/state-api-iot-ensemble/State/IoTEnsembleSharedState.cs
+++ b/state-api-iot-ensemble/State/IoTEnsembleSharedState.cs
@@ -140,6 +140,9 @@ namespace LCU.State.API.IoTEnsemble.State
     {
         [DataMember]
         public virtual int EnterpriseDevicesCount { get; set; }
+
+        [DataMember]
+        public virtual bool AddingDevice { get; set; }
         
         [DataMember]
         public virtual List<IoTEnsembleDeviceInfo> Devices { get; set; }

--- a/state-api-iot-ensemble/State/IoTEnsembleSharedState.cs
+++ b/state-api-iot-ensemble/State/IoTEnsembleSharedState.cs
@@ -225,6 +225,9 @@ namespace LCU.State.API.IoTEnsemble.State
         public virtual string ID { get; set; }
 
         [DataMember]
+        public virtual bool IsExpanded { get; set; }
+
+        [DataMember]
         public virtual MetadataModel SensorMetadata { get; set; }
 
         [DataMember]

--- a/state-api-iot-ensemble/State/IoTEnsembleSharedStateHarness.cs
+++ b/state-api-iot-ensemble/State/IoTEnsembleSharedStateHarness.cs
@@ -832,7 +832,7 @@ namespace LCU.State.API.IoTEnsemble.State
                 throw new Exception("Unable to load the user's enterprise, please try again or contact support.");
         }
 
-        public virtual async Task UpdateTelemetrySync(SecurityManagerClient secMgr, DocumentClient client, int refreshRate, int page, int pageSize)
+        public virtual async Task UpdateTelemetrySync(SecurityManagerClient secMgr, DocumentClient client, int refreshRate, int page, int pageSize, string payloadId)
         {
             if (!State.UserEnterpriseLookup.IsNullOrEmpty())
             {
@@ -841,6 +841,10 @@ namespace LCU.State.API.IoTEnsemble.State
                 State.Telemetry.Page = page;
 
                 State.Telemetry.PageSize = pageSize;
+
+                if(payloadId != null){
+                    State.ExpandedPayloadID = payloadId;
+                }
 
                 await LoadTelemetry(secMgr, client);
             }

--- a/state-api-iot-ensemble/State/IoTEnsembleSharedStateHarness.cs
+++ b/state-api-iot-ensemble/State/IoTEnsembleSharedStateHarness.cs
@@ -97,6 +97,8 @@ namespace LCU.State.API.IoTEnsemble.State
 
                             log.LogInformation($"Enroll device status {State.DevicesConfig.Status.ToJSON()}");
 
+                            State.DevicesConfig.AddingDevice = false;
+
                             return !State.DevicesConfig.Status;
                         }
                         catch (Exception ex)
@@ -565,12 +567,16 @@ namespace LCU.State.API.IoTEnsemble.State
         public virtual async Task LoadDevices(ApplicationArchitectClient appArch)
         {
             var devices = await loadDevices(appArch, State.UserEnterpriseLookup, State.DevicesConfig.Page, State.DevicesConfig.PageSize);
-
+            State.DevicesConfig.AddingDevice = true;
             if (devices != null)
             {
                 State.DevicesConfig.Devices = devices.Items.ToList();
 
                 State.DevicesConfig.TotalDevices = devices.TotalRecords;
+                
+                if (State.DevicesConfig.TotalDevices > 0) {
+                    State.DevicesConfig.AddingDevice = false;
+                }
             }
 
             State.DevicesConfig.SASTokens = null;

--- a/state-api-iot-ensemble/State/IoTEnsembleSharedStateHarness.cs
+++ b/state-api-iot-ensemble/State/IoTEnsembleSharedStateHarness.cs
@@ -844,6 +844,7 @@ namespace LCU.State.API.IoTEnsemble.State
 
                 if(!payloadId.IsNullOrEmpty()){
                     State.ExpandedPayloadID = payloadId;
+                    return;
                 }
 
                 await LoadTelemetry(secMgr, client);

--- a/state-api-iot-ensemble/State/IoTEnsembleSharedStateHarness.cs
+++ b/state-api-iot-ensemble/State/IoTEnsembleSharedStateHarness.cs
@@ -832,7 +832,7 @@ namespace LCU.State.API.IoTEnsemble.State
                 throw new Exception("Unable to load the user's enterprise, please try again or contact support.");
         }
 
-        public virtual async Task UpdateTelemetrySync(SecurityManagerClient secMgr, DocumentClient client, int refreshRate, int page, int pageSize, string payloadId)
+        public virtual async Task UpdateTelemetrySync(SecurityManagerClient secMgr, DocumentClient client, int refreshRate, int page, int pageSize, string payloadId=null)
         {
             if (!State.UserEnterpriseLookup.IsNullOrEmpty())
             {
@@ -842,7 +842,7 @@ namespace LCU.State.API.IoTEnsemble.State
 
                 State.Telemetry.PageSize = pageSize;
 
-                if(payloadId != null){
+                if(!payloadId.IsNullOrEmpty()){
                     State.ExpandedPayloadID = payloadId;
                 }
 

--- a/state-api-iot-ensemble/State/IoTEnsembleState.cs
+++ b/state-api-iot-ensemble/State/IoTEnsembleState.cs
@@ -63,10 +63,6 @@ namespace LCU.State.API.IoTEnsemble.State
         [DataMember]
         public virtual List<IoTEnsembleTelemetryPayload> Payloads { get; set; }
 
-        
-        [DataMember]
-        public virtual bool PayloadExpanded { get; set; }
-
         [DataMember]
         public virtual int Page { get; set; }
 
@@ -82,8 +78,6 @@ namespace LCU.State.API.IoTEnsemble.State
         #region Constructors
         public IoTEnsembleTelemetry()
         {
-            PayloadExpanded = false;
-
             RefreshRate = 30;
 
             PageSize = 10;

--- a/state-api-iot-ensemble/State/IoTEnsembleState.cs
+++ b/state-api-iot-ensemble/State/IoTEnsembleState.cs
@@ -63,6 +63,10 @@ namespace LCU.State.API.IoTEnsemble.State
         [DataMember]
         public virtual List<IoTEnsembleTelemetryPayload> Payloads { get; set; }
 
+        
+        [DataMember]
+        public virtual bool PayloadExpanded { get; set; }
+
         [DataMember]
         public virtual int Page { get; set; }
 
@@ -78,6 +82,8 @@ namespace LCU.State.API.IoTEnsemble.State
         #region Constructors
         public IoTEnsembleTelemetry()
         {
+            PayloadExpanded = false;
+
             RefreshRate = 30;
 
             PageSize = 10;


### PR DESCRIPTION
State changes to stop device enrollment and telemetry table windows from closing on state refresh